### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ version: '3'
 
 services:
   FireMail:
-    image: luofengyuan/FireMail:latest
+    image: luofengyuan/firemail:latest
     container_name: firemail
     restart: unless-stopped
     ports:


### PR DESCRIPTION
update docker-compose.yml.
reason: when exec `docker compose up`, something error,it say unable to get image 'luofengyuan/FireMail:latest': Error response from daemon: invalid reference format: repository name (luofengyuan/FireMail) must be lowercase